### PR TITLE
chore: give CRLF to each end of lines

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "crlf"
+}


### PR DESCRIPTION
I noticed that the newline code can be CRLF or LF depending on the file. This PR proposes to specify CRLF as the newline code for all files by providing the value `crlf` for the `endOfLline` field in the Prettier configuration file.

This PR will be changed from draft to final after all other PRs have been merged or rejected and after adding a commit to have Prettier format files.