### PR TITLE
fix issue #78

### DIFF
--- a/src/features/checkCompulsory.ts
+++ b/src/features/checkCompulsory.ts
@@ -89,7 +89,9 @@ export const checkCompulsory = (
           const unit = searchCourse("id", id, courseList).unit;
           detectedCourses.push(searchCourse("id", id, courseList));
           excludeCourseList.push(searchCourse("id", id, courseList));
-          unitCount += unit;
+          if (!isFailed(searchCourse("id", id, courseList).grade)) {
+            unitCount += unit;
+          }
         });
 
       compulsoryResultList.push({


### PR DESCRIPTION
![image](https://github.com/Mimori256/Graduation-Checker/assets/80367947/7cac284f-12f2-473c-aa6e-4b9e47fbe815)
#78 に対応。情報、体育、必修英語の単位チェックで、成績が D の場合の条件分岐を追加していなかったので修正した。